### PR TITLE
[TA-3943] fix(hasura): local webhook handler url

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
             ## enable debugging mode. It is recommended to disable this in production
             HASURA_GRAPHQL_DEV_MODE: "true"
             HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup, http-log, webhook-log, websocket-log, query-log
-            ACTION_BASE_URL: http://localhost:3000
+            ACTION_BASE_URL: http://host.docker.internal:3000
         volumes:
             - ./hasura/metadata:/hasura-metadata
         ports:

--- a/hasura/config.yaml
+++ b/hasura/config.yaml
@@ -13,7 +13,7 @@ migrations_directory: migrations
 seeds_directory: seeds
 actions:
   kind: synchronous
-  handler_webhook_baseurl: http://localhost:3000
+  handler_webhook_baseurl: http://host.docker.internal:3000
   codegen:
     framework: ""
     output_dir: ""


### PR DESCRIPTION
## Description

This PR includes a fix for hasura's webhook handler url, which was not fetching the hasura actions from `localhost:3000`.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch
- [x] provided a link to the relevant issue or specification
- [x] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [x] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] confirmed `!` in the type prefix if API or client breaking change
- [x] confirmed all author checklist items have been addressed
- [x] reviewed API design and naming
- [x] reviewed documentation is accurate
- [x] reviewed tests and test coverage
- [x] manually tested (if applicable)